### PR TITLE
Fix password avec caractères spéciaux

### DIFF
--- a/core/class/CozyTouchManager.class.php
+++ b/core/class/CozyTouchManager.class.php
@@ -47,7 +47,7 @@ class CozyTouchManager
 			
 			self::$_client = new CozyTouchApiClient(array(
 					'userId' => config::byKey('username', 'cozytouch'),
-					'userPassword' => config::byKey('password', 'cozytouch')
+					'userPassword' => utf8_decode(config::byKey('password', 'cozytouch'))
 			));
 		}
 		return self::$_client;

--- a/core/class/cozytouch.class.php
+++ b/core/class/cozytouch.class.php
@@ -57,7 +57,9 @@ class cozytouch extends eqLogic {
     
     /*************************** Methode d'instance **************************/ 
  
-
+    public function preConfig_password($value) {
+      return utf8_encode($value);
+    }
     /************************** Pile de mise  jour **************************/ 
     
     /* fonction permettant d'initialiser la pile 


### PR DESCRIPTION
Le mot de passe cozytouch (saisi sur la page de configuration du plugin) était invalide s'il contenait un ou plusieurs caractères spéciaux (€ par exemple).
Ce code corrige le problème.