### PR TITLE
Adaptation du plugin pour Jeedom 4.x

### DIFF
--- a/desktop/php/cozytouch.php
+++ b/desktop/php/cozytouch.php
@@ -87,7 +87,7 @@ $eqLogics = eqLogic::byType('cozytouch');
                                 <select class="form-control eqLogicAttr" data-l1key="object_id">
                                     <option value="">{{Aucun}}</option>
                                     <?php
-                                    foreach (object::all() as $object) {
+                                    foreach (jeeObject::all() as $object) {
                                         echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
                                     }
                                     ?>


### PR DESCRIPTION
Closes: #3 

Pour le passage à php 7.x le mot clé object est réservé, Jeedom a donc
utilisé jeeObject à la place de object.

Source : https://github.com/jeedom/core/commit/aa656b8e7d272868a9b959e5d408a839f52c1dd7