### PR TITLE
Issue: cron was executed once per hour instead of each 15mn

### DIFF
--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -33,7 +33,7 @@ function cozytouch_install() {
 		$cron->setFunction('refresh');
 		$cron->setEnable(1);
 		$cron->setDeamon(0);
-		$cron->setSchedule($minute . '/15 * * * *');
+		$cron->setSchedule($minute . '-59/15 * * * *');
 		$cron->setTimeout(5);
 		$cron->save();
 	}
@@ -57,7 +57,7 @@ function cozytouch_update() {
 		$cron->setFunction('refresh');
 		$cron->setEnable(1);
 		$cron->setDeamon(0);
-		$cron->setSchedule($minute . '/15 * * * *');
+		$cron->setSchedule($minute . '-59/15 * * * *');
 		$cron->setTimeout(5);
 		$cron->save();
 	}


### PR DESCRIPTION
Solve bug to get a functionnal cron every 15 minutes based on the start of the plugin.
Actually, cron was executed once per hour due to wrong syntax.