### PR TITLE
Update install.php

### DIFF
--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -54,7 +54,7 @@ function cozytouch_update() {
                 $oldTemplate =$cmd->getTemplate($version,'default');			
 				if (in_array($oldTemplate, $toUpdate)) {
 					$cmd->setTemplate($version, 'cozytouch::' . $oldTemplate);
-					log::add('cozytouch','debug','Template ' . $oldTemplate . ' renamed to ' . $cmd->getTemplate($version,'default'););
+					log::add('cozytouch','debug','Template ' . $oldTemplate . ' renamed to ' . $cmd->getTemplate($version,'default'));
 				}
 			}
 			$cmd->save();


### PR DESCRIPTION
Stupid typo prevent update function to be executed so the cron name is not changed and an error is thrown at execution.