### PR TITLE
php8 compatibility

### DIFF
--- a/core/devices/CozytouchAtlanticHotWater.class.php
+++ b/core/devices/CozytouchAtlanticHotWater.class.php
@@ -355,7 +355,7 @@ class CozytouchAtlanticHotWater extends AbstractCozytouchDevice
 			{
 				$temp=$valuetmp['temp'];
 			}
-            $hotwatercoeff = 100*($temp-self::cold_water)/($valuetmp['targettemp']-self::cold_water);
+            $hotwatercoeff = 100*(floatval($temp)-self::cold_water)/(floatval($valuetmp['targettemp'])-self::cold_water);
             $cmd->setCollectDate('');
             $cmd->event($hotwatercoeff);
             log::add('cozytouch', 'debug', __('Calcul proportion d eau chaude : ', __FILE__).$hotwatercoeff);

--- a/core/devices/CozytouchAtlanticHotWaterCES4.class.php
+++ b/core/devices/CozytouchAtlanticHotWaterCES4.class.php
@@ -297,7 +297,7 @@ class CozytouchAtlanticHotWaterCES4 extends AbstractCozytouchDevice
         $cmd=Cmd::byEqLogicIdAndLogicalId($eqLogic->getId(),CozyTouchStateName::EQ_HOTWATERCOEFF);
 		if (is_object($cmd)) {
 			$temp=0;
-            $hotwatercoeff = 100*($valuetmp['remainingshower'])/($valuetmp['targetshower']);
+            $hotwatercoeff = 100*floatval($valuetmp['remainingshower'])/floatval($valuetmp['targetshower']);
             $cmd->setCollectDate('');
             $cmd->event($hotwatercoeff);
             log::add('cozytouch', 'debug', __('Calcul proportion d eau chaude : ', __FILE__).$hotwatercoeff);

--- a/core/devices/CozytouchAtlanticHotWaterFlatC2.class.php
+++ b/core/devices/CozytouchAtlanticHotWaterFlatC2.class.php
@@ -297,7 +297,7 @@ class CozytouchAtlanticHotWaterFlatC2 extends AbstractCozytouchDevice
         $cmd=Cmd::byEqLogicIdAndLogicalId($eqLogic->getId(),CozyTouchStateName::EQ_HOTWATERCOEFF);
 		if (is_object($cmd)) {
 			$temp=0;
-            $hotwatercoeff = 100*($valuetmp['remainingshower'])/($valuetmp['targetshower']);
+            $hotwatercoeff = 100*floatval($valuetmp['remainingshower'])/floatval($valuetmp['targetshower']);
             $cmd->setCollectDate('');
             $cmd->event($hotwatercoeff);
             log::add('cozytouch', 'debug', __('Calcul proportion d eau chaude : ', __FILE__).$hotwatercoeff);

--- a/core/devices/CozytouchAtlanticHotWaterV3.class.php
+++ b/core/devices/CozytouchAtlanticHotWaterV3.class.php
@@ -349,7 +349,7 @@ class CozytouchAtlanticHotWaterV3 extends AbstractCozytouchDevice
 			{
 				$temp=$valuetmp['temp'];
 			}
-            $hotwatercoeff = 100*($temp-self::cold_water)/($valuetmp['targettemp']-self::cold_water);
+			$hotwatercoeff = 100*(floatval($temp)-self::cold_water)/(floatval($valuetmp['targettemp'])-self::cold_water);
             $cmd->setCollectDate('');
             $cmd->event($hotwatercoeff);
             log::add('cozytouch', 'debug', __('Calcul proportion d eau chaude : ', __FILE__).$hotwatercoeff);


### PR DESCRIPTION
Hello Geoffrey,
Un utilisateur du plugin a trouvé un problème avec les chauffe-eau sous Debian 12 (je n'ai qu'un sèche serviette donc je n'avais pas vu le problème).
C'est en fait un problème avec php8.
Je te propose un fix.
Aussi maintenant que la version beta tourne bien (chez moi avec mon sèche serviettes ça tourne comme une horloge avec le combo Debian 12 et Jeedom 4.5 alpha) peut être pourrais-tu mettre à jour la version stable.
Merci beaucoup.
Jean-Michel